### PR TITLE
ENH: Adequate module tests to ITK test driver structure.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,4 +8,4 @@ CreateTestDriver(TBBImageToImageFilter "${TBBImageToImageFilter-Test_LIBRARIES}"
 
 itk_add_test(NAME itkTBBImageToImageFilterTest
   COMMAND TBBImageToImageFilterTestDriver
-)
+  itkTBBImageToImageFilterTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,11 @@
 itk_module_test()
 
-set(TEST_NAME itkTBBImageToImageFilterTest)
+set(TBBImageToImageFilterTests
+  itkTBBImageToImageFilterTest.cxx
+  )
 
-add_executable(${TEST_NAME}
-    itkTBBImageToImageFilterTest.cxx
+CreateTestDriver(TBBImageToImageFilter "${TBBImageToImageFilter-Test_LIBRARIES}" "${TBBImageToImageFilterTests}")
+
+itk_add_test(NAME itkTBBImageToImageFilterTest
+  COMMAND TBBImageToImageFilterTestDriver
 )
-
-target_link_libraries(${TEST_NAME}
-    ${${itk-module-test}_LIBRARIES}
-)
-
-itk_add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})

--- a/test/itkTBBImageToImageFilterTest.cxx
+++ b/test/itkTBBImageToImageFilterTest.cxx
@@ -73,11 +73,8 @@ public:
 
 } // itk
 
-int itkTBBImageToImageFilterTest(int argc, const char** argv)
+int itkTBBImageToImageFilterTest( int, char* [] )
 {
-  (void)argc;
-  (void)argv;
-
 #ifdef ITK_USE_TBB
   std::cout << "Test TBBImageToImageFilter with TBB library" << std::endl;
 #else

--- a/test/itkTBBImageToImageFilterTest.cxx
+++ b/test/itkTBBImageToImageFilterTest.cxx
@@ -73,7 +73,7 @@ public:
 
 } // itk
 
-int main(int argc, const char** argv)
+int itkTBBImageToImageFilterTest(int argc, const char** argv)
 {
   (void)argc;
   (void)argv;


### PR DESCRIPTION
Use the itkTestDriver to set up the required environment for the test
suite to be run under the ITK testing framework.

Make the necessary modifications to the CMakeLists.txt file.

Rename the test file main method name to adapt to these changes.